### PR TITLE
Adjust position calculation for MoreActionsMenu

### DIFF
--- a/src/components/Explorer/file_explorer/MoreActionsMenu.tsx
+++ b/src/components/Explorer/file_explorer/MoreActionsMenu.tsx
@@ -170,9 +170,10 @@ export class ContextMenuProps {
     event.preventDefault();
     event.stopPropagation();
     this.showCallback(false);
+    const rect = (event.currentTarget as HTMLElement).getBoundingClientRect();
     const positionChange = {
-      x: 200 + 20, // The width is set to 200
-      y: event.pageY,
+      x: rect.right - 200,   
+      y: rect.bottom,
     };
     this.setPositionCallback(positionChange);
     this.showCallback(true);


### PR DESCRIPTION
The MoreActionsMenu dropdown was previously positioned using hardcoded values (x: 200 + 20 and event.pageY), which caused misalignment issues depending on layout size, scroll position, and viewport changes.

This update anchors the dropdown to the clicked element using getBoundingClientRect(), ensuring consistent and accurate positioning relative to the trigger button.

Changes:
- Replaced hardcoded x-offset with element-based positioning.
- Used rect.right and rect.bottom for stable alignment.
- Removed dependency on pageY and static pixel values.